### PR TITLE
adding play script and adding config dump to train_rl

### DIFF
--- a/source/wheeledlab_rl/scripts/play_policy.py
+++ b/source/wheeledlab_rl/scripts/play_policy.py
@@ -1,0 +1,169 @@
+"""
+Play a policy in an environment and record the data.
+
+example usage:
+
+python play/record_policy.py --policy-type PPO --env-name Isaac-MITCar-v0 --policy-path /path/to/policy --log-dir /path/to/log
+
+loading from RSL run:
+
+python play/record_policy.py --rl-algo-lib rsl --load-run <run_name>
+"""
+
+###################################
+###### BEGIN ISAACLAB SPINUP ######
+###################################
+
+from wheeledlab_rl.startup import startup
+import argparse
+parser = argparse.ArgumentParser(description="Play a policy in WheeledLab.")
+# These arguments assume that a run folder can be found
+parser.add_argument('-p', "--run-path", type=str, default=None, help="Path to run folder")
+parser.add_argument("--checkpoint", type=int, default=None, help="Checkpoint to load")
+# If no run folder, the task and policy model must be provided
+parser.add_argument("--task", type=str, default=None, help="Task name. Overrides run config env if provided")
+parser.add_argument("--policy-path", type=str, default=None, help="Path to policy file.")
+# Playback
+parser.add_argument("--steps", type=int, default=200, help="Length of recorded video in steps")
+# Logging
+parser.add_argument('-sd', "--save-data", action="store_true", help="Save episode data")
+parser.add_argument("--video", action="store_true", help="Record video of the playback")
+parser.add_argument("--log-dir", type=str, default="playback/",
+                    help="Directory to save logs. If run path is provided, this is ignored.")
+parser.add_argument("--play-name", type=str, default="play-name", help="Name of the playback")
+
+simulation_app, args_cli = startup(parser=parser)
+### Extract task_name and agent_cfg from run_config.pkl ###
+
+# Validate arguments
+if args_cli.run_path is None:
+    if args_cli.task is None and args_cli.policy_path is None:
+        raise ValueError("Either path to run directory or task/policy must be provided.")
+
+import os
+import gymnasium as gym
+import time
+import torch
+from tqdm import tqdm
+from rsl_rl.runners import OnPolicyRunner
+
+from isaaclab.utils.io import load_pickle
+from isaaclab_tasks.utils import get_checkpoint_path
+from isaaclab_tasks.utils.hydra import hydra_task_config
+from isaaclab.envs import ManagerBasedRLEnvCfg
+from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
+
+from wheeledlab_rl.configs import RunConfig
+from wheeledlab_rl.utils import ClipAction
+
+
+FROM_RUN = args_cli.run_path is not None
+if FROM_RUN:
+    path_to_run_cfg_pkl = os.path.join(args_cli.run_path, "run_config.pkl")
+    run_cfg: RunConfig = load_pickle(path_to_run_cfg_pkl) # load_yaml does not work on slices
+    run_agent_cfg = run_cfg.agent
+    task = run_cfg.env_setup.task_name if args_cli.task is None else args_cli.task
+    agent_entry_point = None
+else:
+    task = args_cli.task
+    agent_entry_point = "rsl_rl_cfg_entry_point" # rsl is the only supported library for now
+
+
+@hydra_task_config(task, agent_entry_point)
+def main(env_cfg: ManagerBasedRLEnvCfg, agent_cfg): # TODO: Add SB3 config support
+
+    if agent_cfg is None:
+        agent_cfg = run_agent_cfg
+
+    if FROM_RUN:
+        playback_dir = os.path.join(args_cli.run_path, "playback")
+    else:
+        playback_dir = args_cli.log_dir
+
+    if not os.path.exists(playback_dir):
+        os.makedirs(playback_dir)
+    print(f"[INFO] Created playback directory: {playback_dir}")
+
+    ####################################
+    #### POLICY LOADING CODE ####
+    ####################################
+
+    env = gym.make(task, cfg=env_cfg, render_mode="rgb_array" if args_cli.video else None)
+
+    if args_cli.video:
+        video_kwargs = {
+            "video_folder": playback_dir,
+            "step_trigger": lambda step: step % args_cli.steps == 0,
+            "video_length": args_cli.steps, # updated to use args_cli
+            "disable_logger": True,
+            "name_prefix": args_cli.play_name,
+        }
+        print(f"[INFO] Recording video of playback to: {playback_dir}")
+        env = gym.wrappers.RecordVideo(env, **video_kwargs)
+
+    env = RslRlVecEnvWrapper(env)
+
+    ############################################
+    ########### BEGIN PLAYBACK SETUP ###########
+    ############################################
+
+    if FROM_RUN:
+        chkpt = args_cli.checkpoint if args_cli.checkpoint is not None else ".*"
+        fp = os.path.abspath(args_cli.run_path)
+        run_dirname = os.path.dirname(fp)
+        run_folder = os.path.basename(fp)
+        policy_resume_path = get_checkpoint_path(log_path=run_dirname, run_dir=run_folder,
+                                            other_dirs=["models"], checkpoint=chkpt)
+    else:
+        policy_resume_path = args_cli.policy_path
+
+    env.action_space.low = -1.
+    env.action_space.high = 1.
+    env = ClipAction(env)
+
+    ppo_runner = OnPolicyRunner(env, agent_cfg.to_dict())
+    ppo_runner.load(policy_resume_path)
+
+    # obtain the trained policy for inference
+    policy = ppo_runner.get_inference_policy(device=env.unwrapped.device)
+
+    # Data storage
+    data = {
+        'observations': [],
+        'actions': [],
+    }
+
+    ### PLAY POLICY ###
+
+    # reset environment
+    obs, _ = env.get_observations()
+    # simulate environment
+    for _ in tqdm(range(args_cli.steps), desc="Playing policy"):
+        # run everything in inference mode
+        with torch.inference_mode():
+            # agent stepping
+            actions = policy(obs)
+            # env stepping
+            obs, _, _, _ = env.step(actions)
+        # save data
+        data['observations'].append(obs)
+        data['actions'].append(actions)
+
+    ###
+
+    ########################
+    ###### SAVE DATA #######
+    ########################
+
+    if args_cli.save_data:
+        for key in data.keys():
+            data[key] = torch.stack(data[key], dim=0)
+        save_path = os.path.join(playback_dir, f"{args_cli.play_name}-rollouts.pt")
+        torch.save(data, save_path)
+        print(f"[INFO] Saved episode data to: {save_path}")
+
+    print("Done playing policy. Closing environment.")
+    env.close()
+
+if __name__ == "__main__":
+    main()

--- a/source/wheeledlab_rl/scripts/play_policy.py
+++ b/source/wheeledlab_rl/scripts/play_policy.py
@@ -1,13 +1,12 @@
 """
 Play a policy in an environment and record the data.
 
-example usage:
+Usage:
 
-python play/record_policy.py --policy-type PPO --env-name Isaac-MITCar-v0 --policy-path /path/to/policy --log-dir /path/to/log
+python scripts/play_policy.py -p <path-to-run> -sd --video
 
-loading from RSL run:
+This command will save data and record a video of the playback using an existing run folder.
 
-python play/record_policy.py --rl-algo-lib rsl --load-run <run_name>
 """
 
 ###################################

--- a/source/wheeledlab_rl/scripts/train_rl.py
+++ b/source/wheeledlab_rl/scripts/train_rl.py
@@ -16,6 +16,7 @@ import gymnasium as gym
 import os
 
 from isaaclab.utils.dict import print_dict
+from isaaclab.utils.io import dump_yaml, dump_pickle
 from isaaclab_tasks.utils import get_checkpoint_path
 from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
 
@@ -46,7 +47,7 @@ def main(run_cfg: RunConfig): # TODO: Add SB3 config support
     if not log_cfg.no_wandb:
         import wandb
         run = wandb.init(
-            project="IRL",
+            project=log_cfg.wandb_project,
         )
         log_cfg.run_name = wandb.run.name
 
@@ -56,6 +57,11 @@ def main(run_cfg: RunConfig): # TODO: Add SB3 config support
     ## UPDATE CONFIGS WANDB ##
     if not log_cfg.no_wandb:
         wandb.config.update(run_cfg.to_dict())
+
+    # Save the config file
+    if not log_cfg.no_log:
+        dump_yaml(os.path.join(log_cfg.run_log_dir, "run_config.yaml"), run_cfg)
+        dump_pickle(os.path.join(log_cfg.run_log_dir, "run_config.pkl"), run_cfg)
 
     ############################
     #### CREATE ENVIRONMENT ####

--- a/source/wheeledlab_rl/wheeledlab_rl/configs/common_cfg.py
+++ b/source/wheeledlab_rl/wheeledlab_rl/configs/common_cfg.py
@@ -22,6 +22,7 @@ class LogConfig:
     no_checkpoints: bool = False                        # Disable saving checkpoints
     checkpoint_every: int = 1000                        # Save checkpoint every n updates
     no_wandb: bool = False                              # Disable wandb logging
+    wandb_project: str = "WheeledLab"                   # Wandb project name
     test_mode: bool = False                             # Test mode (disable logging, wandb, video, checkpoints). Overrides other flags
     model_save_dirname: str = "models"                  # Path to save the model under log_dir
     video_resolution: tuple[int, int] = (1280, 720)     # Resolution of the recorded video, Width x Height


### PR DESCRIPTION
Adds a `play_policy.py` script for playing back and recording data from trained policies.

Adds run config file dumping for `train_rl.py`

Example usage:

```
python scripts/play_policy.py -p <path-to-run> -sd --video
```

This command will save data and record a video of the playback using an existing run folder.
