### PR TITLE
Update README.md installation and VSCode instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contribution Guidelines
+
+Welcome! 
+
+If you have project-related questions, please ask in the General discussion thread so others with similar questions can read the responses too. (Knowledge sharing)
+
+Here are some links to helpful documentation:
+- [IsaacLab](https://isaac-sim.github.io/IsaacLab/main/index.html)
+
+The following templates are just suggestions, not requirements. 
+
+# Pull Request Submission
+
+- Commit Message: Make it descriptive.
+- Summarize your approach so it's easier for reviewers to understand.
+
+# Issues
+
+You can include this information in bullet points or sub-headings:
+
+- Issue description
+- Your OS, IsaacLab, IsaacSim, Python versions.
+- How to duplicate the issue. 
+- What you've tried to fix the issue (if you've tried)
+
+# Feature Request 
+
+We are accepting feature requests, but they aren't the highest priority currently. 
+
+You can use this template: 
+
+- Purpose of feature
+- What is the current implementation missing that could be better 
+- Proposed changes 
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,6 @@ You can include this information in bullet points or sub-headings:
 
 # Feature Request 
 
-We are accepting feature requests, but they aren't the highest priority currently. 
-
 You can use this template: 
 
 - Purpose of feature

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Environments, assets, workflow for open-source mobile robotics, integrated with 
 
 ## Installing IsaacLab (~30 min)
 
+Note: Only use this pip installation approach if you're on Ubuntu 22.04+ or Windows. For Ubuntu 20.04, install from the binaries. [link](https://isaac-sim.github.io/IsaacLab/main/source/setup/installation/index.html)
+
 WheeledLab is built atop Isaac Lab. If you do not yet have Isaac Lab installed, it is open-source and installation instructions for Isaac Sim v4.5.0 and Isaac Lab v2.0.2 can be found below:
 
 ```bash
@@ -125,6 +127,7 @@ STRONGLY advised.
 2. `Ctrl` + `Shift` + `P` to bring up the VSCode command palette. type `Tasks:Run Task` or type until you see it show up and highlight it and press `Enter`.
 3. Click on `setup_python_env`. Follow the prompts until you're able to run the task. You should see a console at the bottom and the status of the task.
 4. If successful, you should now have `.vscode/{settings.json, launch.json}` in your `<WheeledLab>` repo and `settings.json` should have a populated list of paths under the `"python.analysis.extraPaths"` key.
+5. Make sure you at least have Microsoft's Python extension installed for intellisense to work. 
 
 ### If it still doesn't work
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Environments, assets, workflow for open-source mobile robotics, integrated with 
 
 [Website](https://uwrobotlearning.github.io/WheeledLab/) | [Paper](https://arxiv.org/abs/2502.07380)
 
-## Installing IsaacLab (~30 min)
+## Installing IsaacLab (~20 min)
 
 Note: Only use this pip installation approach if you're on Ubuntu 22.04+ or Windows. For Ubuntu 20.04, install from the binaries. [link](https://isaac-sim.github.io/IsaacLab/main/source/setup/installation/index.html)
 
@@ -60,6 +60,8 @@ pip install -e wheeledlab_tasks
 pip install -e wheeledlab_assets
 pip install -e wheeledlab_rl
 ```
+
+After this, we recommend [Setting Up VSCode](https://github.com/UWRobotLearning/WheeledLab?tab=readme-ov-file#training-quick-start).
 
 ## Training Quick Start
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Note: Only use this pip installation approach if you're on Ubuntu 22.04+ or Wind
 WheeledLab is built atop Isaac Lab. If you do not yet have Isaac Lab installed, it is open-source and installation instructions for Isaac Sim v4.5.0 and Isaac Lab v2.0.2 can be found below:
 
 ```bash
-# Create a conda environment named env_isaaclab and install Isaac Sim v4.5.0 in it:
-conda create -n env_isaaclab python=3.10
-conda activate env_isaaclab
+# Create a conda environment named WL and install Isaac Sim v4.5.0 in it:
+conda create -n WL python=3.10
+conda activate WL
 pip install torch==2.5.1 --index-url https://download.pytorch.org/whl/cu121 # Or `pip install torch==2.5.1 --index-url https://download.pytorch.org/whl/cu118` for CUDA 11
 pip install --upgrade pip
 pip install 'isaacsim[all,extscache]==4.5.0' --extra-index-url https://pypi.nvidia.com


### PR DESCRIPTION
I clarified that Ubuntu 22.04 is needed for pip installation. And since I recently set up my VSCode workspace, I realized that the Python extension is needed. I noticed that it wasn't strictly necessary for the setup_python_env task to work. It didn't for me, the extension was enough to get the Isaaclab and other library files to show up with ctrl+click.