### PR TITLE
Fix value unpacking in RL runner to match algorithm return values

### DIFF
--- a/source/wheeledlab_rl/wheeledlab_rl/utils/modified_rsl_rl_runner.py
+++ b/source/wheeledlab_rl/wheeledlab_rl/utils/modified_rsl_rl_runner.py
@@ -119,8 +119,8 @@ class OnPolicyRunner(runners.OnPolicyRunner):
                 mean_value_loss,
                 mean_surrogate_loss,
                 mean_entropy,
-                mean_rnd_loss,
-                mean_symmetry_loss,
+                # mean_rnd_loss,
+                # mean_symmetry_loss,
             ) = self.alg.update()
             stop = time.time()
             learn_time = stop - start


### PR DESCRIPTION
# Fix value unpacking in RL runner to match algorithm return values

## Error
ValueError: not enough values to unpack (expected 5, got 3)


## Description
Fixed a value unpacking error in the modified RSL RL runner where the code was expecting 5 return values from `self.alg.update()` but only receiving 3. This implementation is using the basic PPO algorithm from RSL RL (https://github.com/leggedrobotics/rsl_rl) without the extended research features.

### Changes Made
Modified the value unpacking in `modified_rsl_rl_runner.py` to only expect the three core PPO return values:
- `mean_value_loss`
- `mean_surrogate_loss`
- `mean_entropy`

Removed unpacking of the optional research feature values:
- `mean_rnd_loss` (Random Network Distillation)
- `mean_symmetry_loss` (Symmetry-based Augmentation)

### Context
This fix aligns with the basic PPO implementation we're using with IsaacLab v2.0.2. The extended features (RND and symmetry-based augmentation) are available in the RSL RL library but are not currently enabled in our configuration.

### Error Fixed