### PR TITLE
updating rsl-rl version to >=2.3.0

### DIFF
--- a/source/wheeledlab_rl/setup.py
+++ b/source/wheeledlab_rl/setup.py
@@ -15,7 +15,8 @@ INSTALL_REQUIRES = [
     # NOTE: Add dependencies
     "psutil",
     "rich",
-    "av"
+    "av",
+    "rsl-rl-lib>=2.3.0",
 ]
 
 # Installation operation

--- a/source/wheeledlab_rl/wheeledlab_rl/utils/modified_rsl_rl_runner.py
+++ b/source/wheeledlab_rl/wheeledlab_rl/utils/modified_rsl_rl_runner.py
@@ -115,13 +115,7 @@ class OnPolicyRunner(runners.OnPolicyRunner):
                 start = stop
                 self.alg.compute_returns(critic_obs)
 
-            (
-                mean_value_loss,
-                mean_surrogate_loss,
-                mean_entropy,
-                mean_rnd_loss,
-                mean_symmetry_loss,
-            ) = self.alg.update()
+            loss_dict = self.alg.update()
             stop = time.time()
             learn_time = stop - start
             self.current_learning_iteration = it


### PR DESCRIPTION
 Addresses #20 . Replicating here:

# Error
ValueError: not enough values to unpack (expected 5, got 3)

# Description
Updates the rsl-rl version required by `wheeledlab_rl` to >=2.3.0 which begins to unpack the loss values as a dict.